### PR TITLE
Added helper script for Debian to create a LORIS project directory at…

### DIFF
--- a/tools/create-project.sh
+++ b/tools/create-project.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Creates a stub LORIS project directory at the location passed as the first argument
+mkdir -p $1/data $1/libraries $1/instruments $1/templates $1/tables_sql $1/modules $1/smarty/templates_c

--- a/tools/create-project.sh
+++ b/tools/create-project.sh
@@ -1,3 +1,13 @@
 #!/bin/bash
 # Creates a stub LORIS project directory at the location passed as the first argument
-mkdir -p $1/data $1/libraries $1/instruments $1/templates $1/tables_sql $1/modules $1/smarty/templates_c
+for d in data libraries instruments templates tables_sql modules smarty/templates_c ; do
+    mkdir -p "${1}/${d}"
+done
+
+# Make sure the smarty templates_c directory is writable by Apache.
+# FIXME: Should this be here? If so, does it need to be sudo'ed?
+# FIXME 2: If this stays here, it should be smarty enough to detect
+# the correct user based on distro. For now, this is only used by
+# the Debian packaging script.
+chown www-data "$1/smarty/templates_c"
+chmod 770 "$1/smarty/templates_c"


### PR DESCRIPTION
… an arbitrary location.

`Usage: create-project.sh /var/lib/loris/`