### PR TITLE
Add SQL directory and symlinks for LORIS

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Uploaders: Michael Hanke <mih@debian.org>,
            Cecile Madjar <cecile.madjar@mail.mcgill.ca>
 Section: science
 Priority: optional
-Build-Depends: debhelper (>= 9~), composer
+Build-Depends: debhelper (>= 9~), composer, php-xml
 Standards-Version: 3.9.6
 Vcs-Browser: https://github.com/aces/Loris
 Vcs-Git: https://github.com/aces/Loris.git

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Uploaders: Michael Hanke <mih@debian.org>,
            Cecile Madjar <cecile.madjar@mail.mcgill.ca>
 Section: science
 Priority: optional
-Build-Depends: debhelper (>= 9~),
+Build-Depends: debhelper (>= 9~), composer
 Standards-Version: 3.9.6
 Vcs-Browser: https://github.com/aces/Loris
 Vcs-Git: https://github.com/aces/Loris.git
@@ -14,9 +14,10 @@ Homepage: http://loris.ca
 Package: loris
 Architecture: all
 Depends: php-mysql,
-         php-gd,
-         php-sqlite,
+         php-cli,
          php-json,
+         php-xml,
+         php (>= 7~),
          libapache2-mod-php,
          ${misc:Depends}
 Description: web-accessible database for longitudinal multi-site studies

--- a/debian/install
+++ b/debian/install
@@ -5,6 +5,7 @@ smarty usr/share/loris/
 test usr/share/loris/
 php usr/share/loris/
 tools usr/share/loris/
+SQL usr/share/loris/
 
 composer.json usr/share/loris/
 composer.lock usr/share/loris/

--- a/debian/install
+++ b/debian/install
@@ -6,3 +6,5 @@ test usr/share/loris/
 php usr/share/loris/
 tools usr/share/loris/
 
+composer.json usr/share/loris/
+composer.lock usr/share/loris/

--- a/debian/loris.links
+++ b/debian/loris.links
@@ -1,0 +1,2 @@
+var/lib/loris usr/share/loris/project
+var/lib/loris/smarty/templates_c usr/share/loris/project/smarty/templates_c

--- a/debian/rules
+++ b/debian/rules
@@ -10,6 +10,10 @@ upstreamver = $(shell echo $(debver) | cut -d '-' -f 1,1 )
 # master or whatever other source branch.
 gitver = $(shell [ -x /usr/bin/git ] && git describe --tags --match 'v[0-9]*' $$(git merge-base -a HEAD releases) | sed -e 's/^v//' -e 's/-rc/~rc/' -e 's/-/+git/')
 
+override_dh_install:
+	composer install --no-dev
+	dh_install
+
 # one ring to rule them all ...
 %:
 	dh $@

--- a/debian/rules
+++ b/debian/rules
@@ -11,8 +11,11 @@ upstreamver = $(shell echo $(debver) | cut -d '-' -f 1,1 )
 gitver = $(shell [ -x /usr/bin/git ] && git describe --tags --match 'v[0-9]*' $$(git merge-base -a HEAD releases) | sed -e 's/^v//' -e 's/-rc/~rc/' -e 's/-/+git/')
 
 override_dh_install:
-	composer install --no-dev
+	# We need to remove the project directory created by composer install, which we'll
+	# be replacing with a symlink to /var/lib/loris when we create the project here in
+	# the future.
 	dh_install
+	(cd debian/loris/usr/share/loris && composer install --no-dev && rm -rf project)
 
 # one ring to rule them all ...
 %:


### PR DESCRIPTION
Added the LORIS SQL directory (which is required by the installdb.php frontend) and included symlinks to directories (not yet) created by the create-project.sh script in /var/lib/loris, for things that need to be writeable.